### PR TITLE
Support Alpine linux 🐧

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -28,7 +28,8 @@ action "On Merged|Sync" {
 action "Save perf results" {
 	needs = ["Perf cargo", "Perf CLI release"]
 	uses = "./.github/action/summarize-perf"
-	args = "query '{exec: .command, memory: .memory.peak, cpu: .cpu, time: .mean}' | commit"
+	# args = "query '{exec: .command, memory: .memory.peak, cpu: .cpu, time: .mean}' | commit"
+	args = "query '.'"
 	secrets = ["GITHUB_TOKEN"]
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -28,8 +28,7 @@ action "On Merged|Sync" {
 action "Save perf results" {
 	needs = ["Perf cargo", "Perf CLI release"]
 	uses = "./.github/action/summarize-perf"
-	# args = "query '{exec: .command, memory: .memory.peak, cpu: .cpu, time: .mean}' | commit"
-	args = "query '.'"
+	args = "query '{exec: .command, memory: .memory.peak, cpu: .cpu, time: .mean}' | commit"
 	secrets = ["GITHUB_TOKEN"]
 }
 

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -6,7 +6,7 @@ pub mod prompt {
 }
 
 pub mod print {
-	use prettyprint::{PrettyPrint, PrettyPrinter};
+	use prettyprint::{PagingMode::*, PrettyPrint, PrettyPrinter};
 
 	pub enum Mode {
 		REPL,
@@ -20,6 +20,7 @@ pub mod print {
 			.header(false)
 			.grid(false)
 			.line_numbers(false)
+			.paging_mode(Never) // to support Alpine linux
 			.theme("TwoDark")
 			.language(lang);
 		(match mode /*👆*/ {


### PR DESCRIPTION
Seems command `less` in Alpine has difficulty in printing ANSI escape sequences for color 🤔
```console
# ./scrap code simple.scl
less: unrecognized option: RAW-CONTROL-CHARS
BusyBox v1.29.3 (2019-01-24 07:45:07 UTC) multi-call binary.
Usage: less [-EFIMmNSRh~] [FILE]...
View FILE (or stdin) one screenful at a time
-E      Quit once the end of a file is reached
-F      Quit if entire file fits on first screen
-I      Ignore case in all searches
-M,-m   Display status line with line numbers
and percentage through the file
-N      Prefix line number to each line
-S      Truncate long lines
-R      Remove color escape codes in input
-~      Suppress ~s displayed past EOF
```